### PR TITLE
alternative check for dirty forms

### DIFF
--- a/ringo/static/js/helpers.js
+++ b/ringo/static/js/helpers.js
@@ -29,7 +29,7 @@ function getDTLanguage(language) {
 function checkDirtyForms () {
     var forms = document.getElementsByTagName('FORM');
     forms.forEach( function(form) {
-        if !form.attr("no-dirtyable") {
+        if (!form.attr("no-dirtyable")) {
             var childnodes = form.childNodes;
             childnodes.forEach( function(node) {
                 if (node.tagName === 'INPUT') {

--- a/ringo/static/js/helpers.js
+++ b/ringo/static/js/helpers.js
@@ -19,3 +19,53 @@ function getDTLanguage(language) {
         return "default";
     }
 }
+
+/**
+ * checks if any form in the DOM is dirty, bypassing form and input tags with
+ * the attribute 'no-dirtyable'. Returns true if some change is found
+ * (e.g. < form no-dirtyable>...< /form>)
+ * (e.g. < input type='checkbox' no-dirtyable />)
+ */
+function checkDirtyForms () {
+    var forms = document.getElementsByTagName('FORM');
+    forms.forEach( function(form) {
+        if !form.attr("no-dirtyable") {
+            var childnodes = form.childNodes;
+            childnodes.forEach( function(node) {
+                if (node.tagName === 'INPUT') {
+                    if (!node.attr("no-dirtyable")) {
+                        switch type {
+                            case "checkbox":
+                            case "radio":
+                                if (node.checked != node.defaultChecked) {
+                                    return true;
+                                }
+                                break;
+                            default:
+                                //TODO check if all other input types are
+                                // covered (even html5 ones)
+                                if (node.value != node.defaultValue){
+                                    return true;
+                                }
+                        }
+                    }
+                }
+                else if (node.tagName === 'TEXTAREA') {
+                    if (!node.attr("no-dirtyable")) {
+                        if (node.value != node.defaultValue){
+                            return true;
+                        }
+                    }
+                }
+                else if (node.tagName === 'SELECT') {
+                    if (!node.attr("no-dirtyable")) {
+                        if (node.options[node.selectedIndex].defaultSelected){
+                            return true;
+                        }
+                    }
+                }
+            });
+        }
+    });
+    return false;
+})

--- a/ringo/static/js/init.js
+++ b/ringo/static/js/init.js
@@ -134,22 +134,8 @@ $( document ).ready(function() {
     // Check the initial values of the form and warn the user if the leaves
     // the page without saving the form.
     var DirtyFormWarningOpen = false;
-    $('.formbar-form form').each(function() {
-        $(this).data('initialValue', $(this).serialize());
-    });
     function openDirtyDialog(url, hide_spinner, event) {
-        isDirty = false;
-        $('.formbar-form form').each(function () {
-            if($(this).data('initialValue') != $(this).serialize()){
-                // The DirtyFormWarning should not be shown, if the form
-                // has the attribute "no-dirtyable". See waskiq/issue2049.
-                var no_dirtyable = $(this).attr("no-dirtyable")
-                if(typeof no_dirtyable === typeof undefined
-                   || no_dirtyable != "true") {
-                    isDirty = true;
-                }
-            }
-        });
+        isDirty = checkDirtyForms();
         if((isDirty == true) && (DirtyFormWarningOpen == false)) {
             var dialog = $("#DirtyFormWarning");
             $('#DirtyFormWarningProceedButton').attr("href", url);


### PR DESCRIPTION
Check for changes in form, ignoring tags with the "no-dirtyable" attribute.

Reasoning: As of now, Jquery serializes all input/select/textarea tags and then checks if the initial serialization is different from the current one. This only allows for the whole form to be dirty or not, but not for ignoring single fields. The checkDirtyForms in this PR goes through all relevant fields until a change has been detected.
This is only slightly more performance-expensive, in checking the defaultValue at each field.

**please note that this is still largely untested. It is just a first suggestion.**

