### PR TITLE
fixed correct rendering of html code

### DIFF
--- a/ringo/templates/internal/selection.mako
+++ b/ringo/templates/internal/selection.mako
@@ -36,7 +36,7 @@
 <%def name="render_table_body_checkbox(name, value, selected, visible=True, checker='check')">
   <td>
     <span class="hidden">${"1" if selected else "0"}</span>
-    <input type="checkbox" value="${value}" name="${name}" class="${'' if visible else 'hidden'}" ${'checked=checked' if selected  else ''} onclick="${checker}('${name}', this);"/>
+    <input type="checkbox" value="${value}" name="${name}" class="${'' if visible else 'hidden'}" ${'checked="checked"' if selected  else ''|n} onclick="${checker}('${name}', this);"/>
   </td>
 </%def>
 


### PR DESCRIPTION
reverts 9b808e064bf4672fec95558225186dd798c574ea
and disables default escaping for this string