### PR TITLE
don't check for changes in auxiliary checkboxes

### DIFF
--- a/ringo/templates/internal/dtlist.mako
+++ b/ringo/templates/internal/dtlist.mako
@@ -11,7 +11,7 @@ from ringo.lib.renderer.lists import get_read_update_url
     <tr>
       % if bundled_actions and len(items) > 0:
         <th width="2em" class="checkboxrow">
-        <input type="checkbox" name="check_all" onclick="checkAll('id');">
+        <input type="checkbox" name="check_all" no-dirtyable onclick="checkAll('id');">
       </th>
       % endif
       % for field in tableconfig.get_columns(request.user):

--- a/ringo/templates/internal/list.mako
+++ b/ringo/templates/internal/list.mako
@@ -122,7 +122,7 @@ if sortable:
   <tr>
   % if bundled_actions:
     <th width="2em">
-      <input type="checkbox" name="check_all" onclick="checkAll('id');">
+      <input type="checkbox" name="check_all" no-dirtyable onclick="checkAll('id');">
     </th>
   % endif
   % for num, field in enumerate(tableconfig.get_columns(request.user)):

--- a/ringo/templates/internal/selection.mako
+++ b/ringo/templates/internal/selection.mako
@@ -5,7 +5,7 @@
 <%def name="render_table_header_checkbox(name, multiple=True)">
   <th width="20px" class="checkboxrow">
     % if multiple:
-      <input type="checkbox" name="check_all" onclick="checkAll('${name}');">
+      <input type="checkbox" name="check_all" no-dirtyable onclick="checkAll('${name}');">
     % endif
   </th>
 </%def>


### PR DESCRIPTION
they affect the form, but themselves they don't contain data to be submitted.

I stumbled upon cases where ticking them made the forms "dirty" without any changes being there to submit.