### PR TITLE
reactivated extended dirty form checks

### DIFF
--- a/ringo/static/js/helpers.js
+++ b/ringo/static/js/helpers.js
@@ -44,6 +44,9 @@ function checkDirtyForms () {
                                 return true;
                             }
                             break;
+                        case "search":
+                            // search buttons aren't usually submittable
+                            break;
                         default:
                             //TODO check if all other input types are
                             // covered (even html5 ones)

--- a/ringo/static/js/init.js
+++ b/ringo/static/js/init.js
@@ -138,18 +138,8 @@ $( document ).ready(function() {
         $(this).data('initialValue', $(this).serialize());
     });
     function openDirtyDialog(url, hide_spinner, event) {
-        isDirty = false;
-        $('.formbar-form form').each(function () {
-            if($(this).data('initialValue') != $(this).serialize()){
-                // The DirtyFormWarning should not be shown, if the form
-                // has the attribute "no-dirtyable". See waskiq/issue2049.
-                var no_dirtyable = $(this).attr("no-dirtyable")
-                if(typeof no_dirtyable === typeof undefined
-                    || no_dirtyable != "true") {
-                    isDirty = true;
-                    }
-            }
-        });
+        isDirty = checkDirtyForms();
+
         if((isDirty == true) && (DirtyFormWarningOpen == false)) {
             var dialog = $("#DirtyFormWarning");
             $('#DirtyFormWarningProceedButton').attr("href", url);


### PR DESCRIPTION
Between #47, #52, and #53, we reverted and unreverted some stuff, so that in the end my changes necessary to trigger the new checks disappeared.

I also changed checks for `input type=search` to be ignored, because 'search' is, at least in ringo/formbar not a form field, and can be in a changed state (after a search), but should not be considered 'dirty'. 