### PR TITLE
Feature/hide context menu

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1879,8 +1879,6 @@ The complexity can be configured per overview table using the
 ``table.json`` configuration which is available for all tables in the
 system.
 
-.. _admin_sessiontimer:
-
 Session Timer
 =============
 You can configure to show a session timer widget in the header of the
@@ -1950,6 +1948,18 @@ Default is true, so the menu is shown.
    disable the menu the users will loose access to some default actions like
    changing the ownership. 
 
+The context menu will show on default a entry to show/edit the ownership
+of the currently selected item. You can configure to hide this entry
+in case this option is not used in the application.
+
+.. note::
+
+    The action will always be shown if the user has the `admin` role. 
+
+
+* layout.hide_ownership = false
+
+Default is false, so the ownership menu entry is is shown.
 
 Sessions
 ========

--- a/ringo/templates/base.mako
+++ b/ringo/templates/base.mako
@@ -202,10 +202,12 @@
     <button type="button" class="btn btn-default dropdown-toggle hidden-print"
     data-toggle="dropdown"> ${_('Advanced')} <span class="caret"></span></button>
     <ul id="context-menu-options" class="dropdown-menu  pull-right" role="menu">
-      <li role="presentation" class="dropdown-header">${_('Administration')}</li>
-      <li><a href="${h.get_action_url(request, item, 'ownership')}">${_('Change ownership')}</a></li>
-      % if len(context_actions) > 0:
+      % if request.registry.settings.get("layout.hide_ownership") != "true" or request.user.has_role("admin"):
+        <li role="presentation" class="dropdown-header">${_('Administration')}</li>
+        <li><a href="${h.get_action_url(request, item, 'ownership')}">${_('Change ownership')}</a></li>
         <li class="divider"></li>
+      % endif
+      % if len(context_actions) > 0:
         <li role="presentation" class="dropdown-header">${_('Advanced actions')}</li>
         % for action, icon in context_actions:
           <li>


### PR DESCRIPTION
The ownership menu entry in the context menu is now configurable.
Based on our experience this feature is seldom used anyway. So we can hide this feature to not expose secruity relevant information like owner and group withoiut any need.

The menu is shown on default and must explicit disabled to maintain the existing behaviour. 