### PR TITLE
Feature/disable cookie wildcard

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -2151,6 +2151,12 @@ security.cookie_domain
         Defaults to the current domain and all subdomains (is automatically determined by the
         server). The scope of the cookie will bound to a specific domain.
 
+security.cookie_domain_wildcard
+        Defaults to `true` An auth_tkt cookie will be generated for the
+        wildcard domain. If your site is hosted as example.com this will make
+        the cookie available for sites underneath example.com such as
+        www.example.com.
+
 security.cookie_name
         Defaults to 'auth_tkt'. Needs to be set in case you have multiple
         ringo applications on the same server.

--- a/ringo/lib/security.py
+++ b/ringo/lib/security.py
@@ -162,6 +162,7 @@ def setup_ringo_security(config):
     domain = settings.get("security.cookie_domain")
     httponly = settings.get("security.cookie_httponly", "false") == "true"
     cookie_name = settings.get("security.cookie_name", "auth_tkt")
+    wild_domain = settings.get("security.cookie_domain_wildcard", "true") == "true"
     authn_policy = AuthTktAuthenticationPolicy(secret,
                                                secure=secure,
                                                hashalg='sha512',
@@ -171,6 +172,7 @@ def setup_ringo_security(config):
                                                include_ip=include_ip,
                                                path=path,
                                                domain=domain,
+                                               wild_domain=wild_domain,
                                                http_only=httponly,
                                                cookie_name=cookie_name)
     authz_policy = ACLAuthorizationPolicy()


### PR DESCRIPTION
@matakuka requested this change to be able to configure the authtkt cookie more safe according to M170.2 in BSI security advisory.