### PR TITLE
add rpm dependencies to build on centOS7

### DIFF
--- a/ringo/alembic/env.py
+++ b/ringo/alembic/env.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig

--- a/ringo/scaffolds/basic/+package+/alembic/env.py_tmpl
+++ b/ringo/scaffolds/basic/+package+/alembic/env.py_tmpl
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ requires =
        python-zope-sqlalchemy
        python-xlsxwriter
        python-psycopg2
-       python-invoke
        python2-future
        pytz
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ requires =
        python-zope-sqlalchemy
        python-xlsxwriter
        python-psycopg2
-       python2-future
        pytz
 
 [nosetests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ requires =
        python-waitress
        python-webhelpers
        python-zope-sqlalchemy
-       XlsxWriter
+       python-xlsxwriter
        python-psycopg2
        python-invoke
        python2-future

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ requires =
        python-pyramid
        python-pyramid-beaker
        python-pyramid-handlers
-       python-pyramid-mailer
+       python-pyramid-mailer = 0.14.1
        python-pyramid-mako
        python-pyramid-tm
        python-sqlalchemy
@@ -28,7 +28,11 @@ requires =
        python-waitress
        python-webhelpers
        python-zope-sqlalchemy
-       python-xlsxwriter
+       XlsxWriter
+       python-psycopg2
+       python-invoke
+       python2-future
+       pytz
 
 [nosetests]
 match=^test


### PR DESCRIPTION
Updating setup.cfg so that the rpm has proper requirements.

It is tested in a docker environment by successfully running "ringo-admin --help".

- `pyramid-mailer` in that specific version was introduced in setup.py a few months ago.
- About `XlsxWriter` I am not sure;  that package built with this name on my setup.