### PR TITLE
fixed missing check for non-dirtyable checkbox

### DIFF
--- a/ringo/static/js/helpers.js
+++ b/ringo/static/js/helpers.js
@@ -48,22 +48,24 @@ function checkDirtyForms () {
 };
 
 function checkInput(node){
-    switch (node.type) {
-        case "checkbox":
-        case "radio":
-            if (node.checked != node.defaultChecked) {
-                return true;
-            }
-            break;
-        case "search":
-            // search buttons aren't usually submittable
-            break;
-        default:
-            //TODO check if all other input types are
-            // covered (even html5 ones)
-            if (node.value != node.defaultValue){
-                return true;
-            }
+    if (!node.hasAttribute("no-dirtyable")){
+        switch (node.type) {
+            case "checkbox":
+            case "radio":
+                if (node.checked != node.defaultChecked) {
+                    return true;
+                }
+                break;
+            case "search":
+                // search buttons aren't usually submittable
+                break;
+            default:
+                //TODO check if all other input types are
+                // covered (even html5 ones)
+                if (node.value != node.defaultValue){
+                    return true;
+                }
+        }
     }
     return false;
 }


### PR DESCRIPTION
Refactoring in helpers.js destroyed my exotic use case where a checkbox already "starts" in changed state and I have to ignore it with "no-dirtyable"