### PR TITLE
ignore favicon.ico in history

### DIFF
--- a/ringo/lib/history.py
+++ b/ringo/lib/history.py
@@ -4,7 +4,7 @@ import re
 DOWNLOAD_URL = re.compile(".*\/download\/[0-9]+")
 STATIC_URL = re.compile("\/\w+-static\/.*")
 SET_CURRENT_FORM = re.compile("\/set_current_form_page.*")
-
+FAVICON = re.compile(".*\/favicon\.ico")
 
 def handle_history(event):
     """Is called per subscriber on NewResponse event."""
@@ -44,10 +44,11 @@ class History:
         split = urlparse.urlsplit(url)
         normalized_url = urlparse.urlunsplit(("", "") + split[2:])
 
-        # Ignore Download URLs
+        # Ignore Download URLs and Favicon
         if (DOWNLOAD_URL.match(normalized_url) or
            STATIC_URL.match(normalized_url) or
-           SET_CURRENT_FORM.match(normalized_url)):
+           SET_CURRENT_FORM.match(normalized_url) or
+           FAVICON.match(normalized_url)):
             return
 
         # Ignore URL defined from settings if configured


### PR DESCRIPTION
due to almost all browsers fetching the "favicon" first, we'll need to ignore
such requests. Assumption is that nobody ever wants to go 'back' to that icon