### PR TITLE
Disabled default escaping in templates for mailtext.

### DIFF
--- a/ringo/templates/mails/password_reset_request.mako
+++ b/ringo/templates/mails/password_reset_request.mako
@@ -1,6 +1,6 @@
 ${_('Dear user')},
 
-${_('You have received this email because you requested the reset of your password for ${app_name}: ${username}.', mapping={'app_name': app_name, 'username':username})}
+${_('You have received this email because you requested the reset of your password for ${app_name}: ${username}.', mapping={'app_name': app_name, 'username':username})|n}
 
 
 ${_('To complete the reset of your password you need to confirm reset by clicking the following link:')}


### PR DESCRIPTION
Mako has a default escaping enabled which only makes sense in context of HTML
but not HTML as otherwise special chars would get escaped in Text-Mails.