### PR TITLE
Bugfix/issue95

### DIFF
--- a/ringo/lib/helpers/misc.py
+++ b/ringo/lib/helpers/misc.py
@@ -343,7 +343,13 @@ def get_action_url(request, item, action):
     """
     route_name = get_action_routename(item, action)
     if isinstance(item, object):
-        return request.route_path(route_name, id=item.id)
+        # If backurl is set
+        clazz = request.context.__model__
+        backurl = request.session.get('%s.backurl' % clazz)
+        query = {}
+        if backurl:
+            query['backurl'] = backurl
+        return request.route_path(route_name, id=item.id, _query=query)
     # TODO: Is this code ever reached. See testcase (ti) <2014-02-25 23:17>
     return request.route_path(route_name)
 

--- a/ringo/lib/helpers/misc.py
+++ b/ringo/lib/helpers/misc.py
@@ -344,8 +344,11 @@ def get_action_url(request, item, action):
     route_name = get_action_routename(item, action)
     if isinstance(item, object):
         # If backurl is set
-        clazz = request.context.__model__
-        backurl = request.session.get('%s.backurl' % clazz)
+        if hasattr(request.context, "__model__"):
+            clazz = request.context.__model__
+            backurl = request.session.get('%s.backurl' % clazz)
+        else:
+            backurl = None
         query = {}
         if backurl:
             query['backurl'] = backurl

--- a/ringo/lib/renderer/form.py
+++ b/ringo/lib/renderer/form.py
@@ -71,8 +71,9 @@ def get_link_url(item, request, actionname=None, backurl=False):
             return None
 
         query = {}
-        if not readmode and backurl:
-            query['backurl'] = request.current_route_path()
+        if backurl:
+            clazz = request.context.__model__
+            query['backurl'] = request.session.get('%s.backurl' % clazz) or request.current_route_path()
         return request.route_path(route_name, id=item.id, _query=query)
     return None
 


### PR DESCRIPTION
This is a quick fix for #95. 

Basically we changed to methoeds used for url generation to:

1. Keep a previous set backurl (saved in the session)
2. Generate the backurl also in readmode. This is needed to keep the backurl in case the user switch into update mode.