### PR TITLE
Repair and improve import export

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -2449,6 +2449,29 @@ application!).
 The option *--format {json,csv}* specifies the format of the input data, the
 default being JSON.
 
+A JSON file must contain a list with objects corresponding to the `modulname`.
+Nested JSON files including related objects (corresponding to a
+`relationship <http://docs.sqlalchemy.org/en/rel_1_1/orm/relationship_api.html#sqlalchemy.orm.relationship>`_
+in the model that points to instances of BaseItem) are allowed.
+In case the nested file contains the same object multiple times,
+because it is included as a relation of multiple parent or child items,
+it can only be considered as the same object, if it can be identified by
+either UUID or primary key (see above).
+Otherwise multiple items will be created in the database or the import will
+fail if this is not possible (e.g. due to integrity constraints).
+Nested JSON files will usually be created by export
+(see :ref:`exportconfiguration`).
+
+Items related via a many-to-many relationship with an import item
+can also be given as a list of primary keys that will be resolved during import.
+
+Note that foreign keys, if they are part of relations not included as objects
+in a JSON file, must satisfy constraints in the target database.
+E.g. if an imported item has a foreign key attribute and the related item
+is not part of the import file, the value of the foreign key attribute must
+equal an existing value in the referenced column in the target database.
+
+
 Fixing Sequences
 ================
 After loading data into the database it is often needed to fix the sequences

--- a/ringo/lib/imexport.py
+++ b/ringo/lib/imexport.py
@@ -217,8 +217,7 @@ class Exporter(object):
         exporter specific format (e.g. JSON).
 
         :items: Items which will be exported.
-        :returns: Exported items with UUIDs added where missing
-                  (format depends on the export configuration).
+        :returns: Exported items (format depends on the export configuration).
 
         """
         data = []

--- a/ringo/lib/imexport.py
+++ b/ringo/lib/imexport.py
@@ -332,9 +332,12 @@ class Importer(object):
     def __init__(self, clazz, db=DBSession, use_strict=False):
         """@todo: to be defined1.
 
-        :clazz: The clazz for which we will import data
+        :clazz: The class (inheriting from BaseItem) of the import data
 
         """
+        if not issubclass(clazz, BaseItem):
+            raise TypeError("%s is not a subclass of BaseItem" % clazz)
+
         self._clazz = clazz
         self._db = db
         self._clazz_type = self._get_types(clazz)
@@ -372,43 +375,46 @@ class Importer(object):
         return obj
 
     def _deserialize_relations(self, obj):
-        """Will deserialize items in a MANYTOMANY relation. Other
-        relations do not need to be handled as they should have a
-        foreign key to the related item which is part of the items field
-        anyway. It will replace the id values of the related items with
+        """Deserialize items in a MANYTOMANY relation given as a list
+        of primary keys. It will replace the id values of the related items with
         the loaded items.
+        Other types of relations have a foreign key, which is an attribute at
+        one side of the relation anyway. Thus, the relationship can be
+        established by importing both sides of the relationship.
 
         :obj: Deserialized dictionary from basic deserialisation
         :returns: Deserialized dictionary with additional MANYTOMANY
         relations.
         """
         for field in obj.keys():
+            # Just keep already deserialized relations
+            if (isinstance(obj[field], BaseItem)
+                or isinstance(obj[field], list) and all(
+                    isinstance(i, BaseItem) for i in obj[field])):
+                continue
+
             try:
                 ftype = self._clazz_type[field]
             except KeyError:
-                log.warning("Can not find field %s in %s" % (field, self._clazz_type))
+                log.warning("Can not find field %s in %s"
+                            % (field, self._clazz_type))
                 continue
+
             # Handle all types of relations...
-            if ftype in ["MANYTOMANY", "MANYTOONE", "ONETOONE", "ONETOMANY"]:
-                # Remove the items from the list if they are not MANYTOMANY.
-                if ftype != "MANYTOMANY":
-                    del obj[field]
-                    continue
+            if ftype in ["MANYTOONE", "ONETOONE", "ONETOMANY"]:
+                # Remove related items from object if they are not MANYTOMANY.
+                del obj[field]
+            elif ftype == "MANYTOMANY":
                 clazz = getattr(self._clazz, field).mapper.class_
                 tmp = []
                 for item_id in obj[field]:
-                    if isinstance(item_id, BaseItem):
-                        # Item has been already be deserialized in the
-                        # recursive calls.
-                        tmp.append(item_id)
+                    item = self._db.query(clazz).get(item_id)
+                    if item:
+                        tmp.append(item)
                     else:
-                        item = self._db.query(clazz).get(item_id)
-                        if item:
-                            tmp.append(item)
-                        else:
-                            log.warning(("Can not load '%s' id: %s "
-                                         "Relation '%s' of '%s' not set"
-                                         % (clazz, item_id, field, self._clazz)))
+                        log.warning(("Can not load '%s' id: %s "
+                                     "Relation '%s' of '%s' not set"
+                                     % (clazz, item_id, field, self._clazz)))
                 obj[field] = tmp
         return obj
 
@@ -436,28 +442,27 @@ class Importer(object):
 
         """
         self.load_key = load_key
-        with self._db.no_autoflush:
-            data = self.deserialize(data)
-            imported_items = []
-            factory = self._clazz.get_item_factory()
-            if self._use_strict:
-                factory._use_strict = self._use_strict
-            _ = translate
-            for values in data:
-                id = values.get(load_key)
-                if load_key != "id" and "id" in values:
-                    # Only the database should manage primary keys.
-                    # Except when loading by primary key, allow trying to set it.
-                    del values["id"]
-                try:
-                    item = factory.load(id, field=load_key)
-                    item.set_values(values, use_strict=self._use_strict)
-                    operation = _("UPDATE")
-                except sa.orm.exc.NoResultFound:
-                    item = factory.create(user=user, values=values)
-                    self._db.add(item)
-                    operation = _("CREATE")
-                imported_items.append((item, operation))
+        data = self.deserialize(data)
+        imported_items = []
+        factory = self._clazz.get_item_factory()
+        if self._use_strict:
+            factory._use_strict = self._use_strict
+        _ = translate
+        for values in data:
+            id = values.get(load_key)
+            if load_key != "id" and "id" in values:
+                # Only the database should manage primary keys.
+                # Except when loading by primary key, allow trying to set it.
+                del values["id"]
+            try:
+                item = factory.load(id, field=load_key)
+                item.set_values(values, use_strict=self._use_strict)
+                operation = _("UPDATE")
+            except sa.orm.exc.NoResultFound:
+                item = factory.create(user=user, values=values)
+                self._db.add(item)
+                operation = _("CREATE")
+            imported_items.append((item, operation))
         return imported_items
 
 
@@ -469,12 +474,13 @@ class JSONImporter(Importer):
             if isinstance(obj[field], (dict, list)):
                 clazz = getattr(self._clazz, field).mapper.class_
                 importer = JSONImporter(clazz, db=self._db, use_strict=self._use_strict)
-                if not isinstance(obj[field], list):
+                if isinstance(obj[field], dict):
                     import_data = [obj[field]]
                     imported_item = importer.perform(json.dumps(import_data),
                                                      load_key=self.load_key)
                     obj[field] = imported_item[0][0]
-                elif obj[field] and isinstance(obj[field][0], dict):
+                elif (obj[field] and all(
+                        isinstance(i, dict) for i in obj[field])):
                     import_data = obj[field]
                     imported_item = importer.perform(json.dumps(import_data),
                                                      load_key=self.load_key)

--- a/ringo/lib/imexport.py
+++ b/ringo/lib/imexport.py
@@ -444,20 +444,16 @@ class Importer(object):
                 factory._use_strict = self._use_strict
             _ = translate
             for values in data:
-                if load_key == "uuid":
-                    id = values.get('uuid')
-                    if "id" in values:
-                        del values["id"]
-                    load_key = "uuid"
-                else:
-                    id = values.get(load_key)
+                id = values.get(load_key)
+                if load_key != "id" and "id" in values:
+                    # Only the database should manage primary keys.
+                    # Except when loading by primary key, allow trying to set it.
+                    del values["id"]
                 try:
                     item = factory.load(id, field=load_key)
                     item.set_values(values, use_strict=self._use_strict)
                     operation = _("UPDATE")
                 except sa.orm.exc.NoResultFound:
-                    if ("id" in values and not values["id"]):
-                        del values["id"]
                     item = factory.create(user=user, values=values)
                     self._db.add(item)
                     operation = _("CREATE")

--- a/ringo/tests/unit/test_base_model.py
+++ b/ringo/tests/unit/test_base_model.py
@@ -32,12 +32,14 @@ class BaseItemTests(unittest.TestCase):
         result = unicode(item)
         self.assertEqual(result, u"modules")
 
-    def test_json(self):
-        from ringo.lib.imexport import JSONExporter
+    def test_json_imexport(self):
+        from ringo.lib.imexport import JSONExporter, JSONImporter
         item = self._load_item()
         exporter = JSONExporter(item.__class__)
         result = exporter.perform([item])
-        self.assertEqual(len(result), len('[{"str_repr": "%s|name", "description": "", "name": "modules", "label": "Modul", "default_gid": "", "id": "1", "label_plural": "Modules", "display": "admin-menu", "clazzpath": "ringo.model.modul.ModulItem", "uuid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]'))
+        imported = JSONImporter(item.__class__).perform(result)
+        self.assertEqual(len(imported), 1)
+        self.assertEqual(imported[0][1], "UPDATE")
 
     def test_get_form_config(self):
         from ringo.model.modul import ModulItem

--- a/ringo/tests/unit/test_imexport.py
+++ b/ringo/tests/unit/test_imexport.py
@@ -1,5 +1,7 @@
 import pytest
 import json
+import copy
+import uuid
 
 pytestmark = pytest.mark.usefixtures("config")
 
@@ -21,6 +23,7 @@ def expected_item():
         """
     )
 
+
 @pytest.fixture()
 def import_item(expected_item):
     import_item = expected_item
@@ -28,10 +31,12 @@ def import_item(expected_item):
     del import_item["uuid"]
     return import_item
 
+
 @pytest.fixture()
 def import_byid_item(import_item):
     del import_item["id"]
     return import_item
+
 
 @pytest.fixture()
 def update_import_byuuid_item(import_item):
@@ -41,6 +46,78 @@ def update_import_byuuid_item(import_item):
     import_item["uuid"] = DBSession.query(
         User.uuid).filter(User.id == import_item["id"]).scalar()
     return import_item
+
+
+@pytest.fixture()
+def nested_import_item(import_item):
+    # many-to-one relation
+    import_item["usergroup"] = json.loads(
+        """
+        {
+        "uid": 1,
+        "gid": 1,
+        "name": "testgroup",
+        "description": "test"
+        }
+        """
+    )
+
+    # one-to-one relation
+    import_item["profile"] = json.loads(
+        """
+        [{
+        "uid": 1,
+        "gid": 1,
+        "first_name": "Test"
+        }]
+        """
+    )
+
+    # many-to-many relation
+    import_item["roles"] = json.loads(
+        """
+        [{
+        "label": "Test-role",
+        "name": "testrole",
+        "admin": false,
+        "gid": 1,
+        "uid": 1
+        },
+        {
+        "label": "Another Test-role",
+        "name": "testrole2",
+        "admin": false,
+        "gid": 1,
+        "uid": 1
+        }]
+        """
+    )
+
+    return import_item
+
+
+@pytest.fixture()
+def nested_import_items(nested_import_item):
+    from ringo.lib.sql import DBSession
+    from ringo.lib.imexport import JSONExporter
+    from ringo.model.user import Usergroup, Role
+
+    import_items = [nested_import_item, copy.deepcopy(nested_import_item)]
+    import_items[1]["login"] = "test2"
+
+    # update-import relations of second item
+    import_items[1]["usergroup"] = json.loads(
+        JSONExporter(Usergroup, serialized=False).perform(
+            DBSession.query(Usergroup).filter(Usergroup.name == 'users').one()))
+    import_items[1]["roles"] = json.loads(
+        JSONExporter(Role, serialized=False).perform(
+            DBSession.query(Role).all()))
+
+    # Identifiable related object can appear multiple times
+    import_items[0]["roles"][0]["uuid"] = str(uuid.uuid4())
+    import_items[1]["roles"].append(import_items[0]["roles"][0])
+
+    return import_items
 
 
 def test_item_export(expected_item):
@@ -135,3 +212,45 @@ class TestJSONImport(object):
         assert len(imported_items) == 1
         assert imported_items[0][1] == "CREATE"
         assert imported_items[0][0].login == import_item["login"]
+
+
+    def test_recursive_import(self, nested_import_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+
+        imported_items = JSONImporter(User).perform(
+            json.dumps(nested_import_item))
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "CREATE"
+        assert (imported_items[0][0].usergroup.name
+                == nested_import_item["usergroup"]["name"])
+        assert (imported_items[0][0].profile[0].first_name
+                == nested_import_item["profile"][0]["first_name"])
+        assert (len(imported_items[0][0].roles)
+                == len(nested_import_item["roles"]))
+        assert (imported_items[0][0].roles[0].name
+                == nested_import_item["roles"][0]["name"])
+
+
+    def test_recursive_import_multiple(self, nested_import_items):
+        from ringo.model.user import User, Usergroup, Role
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+
+        group_count = DBSession.query(Usergroup).count()
+        role_count = DBSession.query(Role).count()
+        imported_items = JSONImporter(User).perform(
+            json.dumps(nested_import_items))
+        DBSession.flush()
+
+        assert len(imported_items) == 2
+        assert all(i[1] == "CREATE" for i in imported_items)
+        # plus automatically created and one imported (not updated) groups:
+        assert (DBSession.query(Usergroup).count()
+                == group_count + len(nested_import_items) + 1)
+        # plus imported (not updated) groups:
+        assert (DBSession.query(Role).count()
+                == role_count + len(nested_import_items[0]["roles"]))

--- a/ringo/tests/unit/test_imexport.py
+++ b/ringo/tests/unit/test_imexport.py
@@ -1,0 +1,137 @@
+import pytest
+import json
+
+pytestmark = pytest.mark.usefixtures("config")
+
+@pytest.fixture()
+def expected_item():
+    return json.loads(
+        """
+        {"default_gid": null,
+        "uuid": "",
+        "activated": true,
+        "gid": 1,
+        "last_login": "",
+        "sid": 1,
+        "login": "admin",
+        "password": "xxx",
+        "id": 1,
+        "activation_token": "",
+        "uid": 1}
+        """
+    )
+
+@pytest.fixture()
+def import_item(expected_item):
+    import_item = expected_item
+    import_item["login"] = "test"
+    del import_item["uuid"]
+    return import_item
+
+@pytest.fixture()
+def import_byid_item(import_item):
+    del import_item["id"]
+    return import_item
+
+@pytest.fixture()
+def update_import_byuuid_item(import_item):
+    from ringo.lib.sql import DBSession
+    from ringo.model.user import User
+
+    import_item["uuid"] = DBSession.query(
+        User.uuid).filter(User.id == import_item["id"]).scalar()
+    return import_item
+
+
+def test_item_export(expected_item):
+    from ringo.model.base import BaseFactory
+    from ringo.model.user import User
+    from ringo.lib.imexport import JSONExporter
+
+    user = BaseFactory(User).load(1)
+    export = json.loads(JSONExporter(User, serialized=False).perform(user))
+
+    assert sorted(export.keys()) == sorted(expected_item.keys())
+
+    for key in [key for key in expected_item.keys()
+                if key not in ["uuid", "last_login", "password"]]:
+        assert export[key] == expected_item[key]
+
+
+class TestJSONImport(object):
+
+    def test_import(self, import_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+        from ringo.model.base import BaseFactory
+
+        imported_items = JSONImporter(User).perform(json.dumps(import_item))
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "CREATE"
+        assert (imported_items[0][0]
+                is BaseFactory(User).load(imported_items[0][0].id))
+
+
+    def test_update_import(self, update_import_byuuid_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+        from ringo.model.base import BaseFactory
+
+        imported_items = JSONImporter(User).perform(
+            json.dumps(update_import_byuuid_item))
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "UPDATE"
+        assert (BaseFactory(User).load(update_import_byuuid_item["uuid"],
+                                       field="uuid").login
+                == update_import_byuuid_item["login"])
+
+
+    def test_import_byid(self, import_byid_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+
+        imported_items = JSONImporter(User).perform(json.dumps(import_byid_item),
+                                                    load_key = "id")
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "CREATE"
+        assert imported_items[0][0].login == import_byid_item["login"]
+
+
+    def test_update_import_byid(self, import_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+        from ringo.model.base import BaseFactory
+
+        imported_items = JSONImporter(User).perform(
+            json.dumps(import_item),
+            load_key = "id")
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "UPDATE"
+        assert (BaseFactory(User).load(import_item["id"]).login
+                == import_item["login"])
+
+
+    def test_import_byname(self, import_item):
+        from ringo.model.user import User
+        from ringo.lib.imexport import JSONImporter
+        from ringo.lib.sql import DBSession
+
+        imported_items = JSONImporter(User).perform(json.dumps(import_item),
+                                                    load_key = "login")
+        DBSession.flush()
+
+        assert len(imported_items) == 1
+        assert imported_items[0][1] == "CREATE"
+        assert imported_items[0][0].login == import_item["login"]


### PR DESCRIPTION
Importing nested JSON files did not work actually because the relations build up in JSONImporter._deserialize_recursive() were removed in Importer._deserialize_relations() called afterwards in JSONImporter._deserialize_hook(). This is fixed with this PR, which also includes more documentation for the import of nested JSON files, tests and minor fixes.